### PR TITLE
下書き記事は URL を指定しても詳細画面が開けないようにする

### DIFF
--- a/lib/kazip_web/live/article_live/show.ex
+++ b/lib/kazip_web/live/article_live/show.ex
@@ -10,14 +10,19 @@ defmodule KazipWeb.ArticleLive.Show do
 
   @impl true
   def handle_params(%{"id" => id}, _, socket) do
-    {:noreply,
-     socket
-     |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:article, Articles.get_article!(id))}
-  end
+    article = Articles.get_article!(id)
 
-  defp page_title(:show), do: "Show Article"
-  defp page_title(:edit), do: "Edit Article"
+    socket =
+      unless article.status == 0 do
+        socket
+        |> assign(:page_title, article.title)
+        |> assign(:article, article)
+      else
+        redirect(socket, to: ~p"/")
+      end
+
+    {:noreply, socket}
+  end
 
   def parse_markdown(markdown) do
     Earmark.as_html!(markdown)


### PR DESCRIPTION
下書き記事の詳細にアクセスした場合、ホームページにリダイレクトするようにしました

Fixes #12