### PR TITLE
詳細画面に投稿者の名前を表示する (#75)

### DIFF
--- a/lib/kazip/articles.ex
+++ b/lib/kazip/articles.ex
@@ -84,7 +84,7 @@ defmodule Kazip.Articles do
       ** (Ecto.NoResultsError)
 
   """
-  def get_article!(id), do: Repo.get!(Article, id) |> Repo.preload(:category)
+  def get_article!(id), do: Repo.get!(Article, id) |> Repo.preload([:category, :account])
 
   def get_category!(id), do: Repo.get!(Category, id)
 

--- a/lib/kazip_web/live/article_live/show.html.heex
+++ b/lib/kazip_web/live/article_live/show.html.heex
@@ -10,13 +10,18 @@
   </:actions>
 </.header>
 
+<div class="my-8 text-right text-slate-700 dark:text-slate-400">
+  <ul class="list-none">
+    <li>
+      投稿日: <%= @article.submit_date.year %>/<%= @article.submit_date.month %>/<%= @article.submit_date.day %>
+    </li>
+    
+    <li>投稿者: <%= @article.account.email %></li>
+  </ul>
+</div>
+
 <div class="article_body">
-  <div class="mt-8 text-right text-slate-700 dark:text-slate-400">
-    投稿日:
-    <%= @article.submit_date.year %>/<%= @article.submit_date.month %>/<%= @article.submit_date.day %>
-  </div>
-  
-   <%= @article.body |> parse_markdown |> raw %>
+  <%= @article.body |> parse_markdown |> raw %>
 </div>
 
 <.back navigate={~p"/"}>記事一覧に戻る</.back>

--- a/test/kazip/articles_test.exs
+++ b/test/kazip/articles_test.exs
@@ -6,6 +6,8 @@ defmodule Kazip.ArticlesTest do
   import Kazip.ArticlesFixtures
   import Kazip.AccountsFixtures
 
+  alias Kazip.Articles.Article
+
   setup do
     account = account_fixture()
     %{
@@ -39,8 +41,8 @@ defmodule Kazip.ArticlesTest do
       assert Articles.list_articles(account.id, :limited) == [article]
     end
 
-    test "get_article!/1 returns the article with given id", %{public_article: article} do
-      assert Articles.get_article!(article.id) == article
+    test "get_article!/1 returns the article with given id", %{public_article: %{id: id} = article} do
+      assert %Article{id: ^id} = Articles.get_article!(article.id)
     end
 
     test "create_article/1 with valid data creates a article", %{account: account} do
@@ -68,9 +70,9 @@ defmodule Kazip.ArticlesTest do
       assert article.status == 1
     end
 
-    test "update_article/2 with invalid data returns error changeset", %{public_article: article} do
+    test "update_article/2 with invalid data returns error changeset", %{public_article: %{id: id} = article} do
       assert {:error, %Ecto.Changeset{}} = Articles.update_article(article, @invalid_attrs)
-      assert article == Articles.get_article!(article.id)
+      assert %Article{id: ^id} = Articles.get_article!(article.id)
     end
 
     test "delete_article/1 deletes the article", %{public_article: article} do

--- a/test/kazip_web/live/article_live_test.exs
+++ b/test/kazip_web/live/article_live_test.exs
@@ -5,6 +5,8 @@ defmodule KazipWeb.ArticleLiveTest do
   import Kazip.ArticlesFixtures
   import Kazip.AccountsFixtures
 
+  alias Kazip.Repo
+
   @create_attrs %{body: "some body", title: "some title", status: 1}
   @update_attrs %{body: "some updated body", title: "some updated title", status: 1, category_id: 1}
   @invalid_attrs %{body: nil, title: nil, status: 0}
@@ -133,8 +135,10 @@ defmodule KazipWeb.ArticleLiveTest do
     test "displays article", %{conn: conn, public_article: article} do
       {:ok, _show_live, html} = live(conn, ~p"/articles/#{article}")
 
+      article = Repo.preload(article, :account)
+
       assert html =~ article.title
-      assert html =~ article.account.email
+      assert html =~ "投稿者: #{article.account.email}"
       assert html =~ article.body
     end
 

--- a/test/kazip_web/live/article_live_test.exs
+++ b/test/kazip_web/live/article_live_test.exs
@@ -134,6 +134,7 @@ defmodule KazipWeb.ArticleLiveTest do
       {:ok, _show_live, html} = live(conn, ~p"/articles/#{article}")
 
       assert html =~ article.title
+      assert html =~ article.account.email
       assert html =~ article.body
     end
 


### PR DESCRIPTION
詳細画面に投稿者の名前（メアド）を追加しました
fix #75